### PR TITLE
Use export default with class name if possible

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -85,13 +85,6 @@
     });
 
     // good
-    class ReservationCard extends React.Component {
-    }
- 
-    export default ReservationCard;
-
-
-    // better
     export default class ReservationCard extends React.Component {
     }
     ```

--- a/react/README.md
+++ b/react/README.md
@@ -89,6 +89,11 @@
     }
  
     export default ReservationCard;
+
+
+    // better
+    export default class ReservationCard extends React.Component {
+    }
     ```
 
 ## Alignment


### PR DESCRIPTION
In the style guide, it says not to use displayName, which I am fine with, but it seems like it discourages the use of `export default` when you can still name a class with

``` javascript
export default class SomeComponent extends Component {}
```

I think this syntax is better than 

``` javascript
class Something {}
export default Something
```
