### PR TITLE
enforce 120 chars per line instead of 80

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -78,6 +78,7 @@
 /**
  * Best practices
  */
+    "max-len": [2, 120, 4],          // http://eslint.org/docs/rules/max-len.html
     "consistent-return": 2,          // http://eslint.org/docs/rules/consistent-return
     "curly": [2, "multi-line"],      // http://eslint.org/docs/rules/curly
     "default-case": 2,               // http://eslint.org/docs/rules/default-case

--- a/linters/SublimeLinter/SublimeLinter.sublime-settings
+++ b/linters/SublimeLinter/SublimeLinter.sublime-settings
@@ -64,8 +64,8 @@
       // Warn when variables are defined but never used.
       "unused": true,
       
-      // Enforce line length to 80 characters
-      "maxlen": 80,
+      // Enforce line length to 120 characters
+      "maxlen": 120,
 
       // Enforce placing 'use strict' at the top function scope
       "strict": true

--- a/linters/jshintrc
+++ b/linters/jshintrc
@@ -35,7 +35,7 @@
   "latedef": true,
 
   // Enforce line length to 80 characters
-  "maxlen": 80,
+  "maxlen": 120,
 
   // Require capitalized names for constructor functions.
   "newcap": true,

--- a/linters/jshintrc
+++ b/linters/jshintrc
@@ -34,7 +34,7 @@
   // Prohibit use of a variable before it is defined.
   "latedef": true,
 
-  // Enforce line length to 80 characters
+  // Enforce line length to 120 characters
   "maxlen": 120,
 
   // Require capitalized names for constructor functions.


### PR DESCRIPTION
we all have pretty hi-res monitors now, i think we can spare 40 more characters -- or just not enforce this at all?
