### PR TITLE
Arrow functions in react

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -241,21 +241,25 @@
   - When using ES2015 syntax and declaring your components as `class MyComponent extends React.Components {}` you should use arrow functions to define functions that will need to be bound to the components scope. This removes the need to have `.bind()` ran on every render. The arrow function will have the lexical `this` of the component.
   ```javascript
   // bad
-  onClick() {
-    // do stuff
-  }
+  class MyComponent extends React.Component {
+    onLinkClick() {
+      // do stuff
+    }
 
-  render() {
-    return <a onClick={this.onClick.bind(this)}>Clicky</a>;
+    render() {
+      return <a onClick={this.onClick.bind(this)}>Clicky</a>;
+    }
   }
 
   // good
-  onClick = () => {
-    // do stuff
-  }
+  class MyComponent extends React.Component {
+    onLinkClick = () => {
+      // do stuff
+    }
 
-  render() {
-    return <a onClick={this.onClick}>Clickier</a>;
+    render() {
+      return <a onClick={this.onClick}>Clicky</a>;
+    }
   }
   ```
 

--- a/react/README.md
+++ b/react/README.md
@@ -14,6 +14,7 @@
   1. [Parentheses](#parentheses)
   1. [Tags](#tags)
   1. [Methods](#methods)
+  1. [Arrow Functions](#arrow-functions)
   1. [Ordering](#ordering)
 
 ## Basic Rules
@@ -245,7 +246,7 @@
   }
 
   render() {
-    return <a onClick={this.onClick.bind(this)}>Clicky Link</a>;
+    return <a onClick={this.onClick.bind(this)}>Clicky</a>;
   }
 
   // good
@@ -254,7 +255,7 @@
   }
 
   render() {
-    return <a onClick={this.onClick}>Clickier Link</a>;
+    return <a onClick={this.onClick}>Clickier</a>;
   }
   ```
 
@@ -263,7 +264,7 @@
 ## Ordering
 
   - Ordering for class extends React.Component:
-  
+ 
   1. constructor
   1. optional static methods
   1. getChildContext

--- a/react/README.md
+++ b/react/README.md
@@ -219,7 +219,7 @@
     ```javascript
     // bad
     React.createClass({
-      _onClickSubmit() {
+      _myComponentMethod() {
         // do stuff
       }
 
@@ -228,13 +228,37 @@
 
     // good
     class extends React.Component {
-      onClickSubmit() {
+      myComponentMethod() {
         // do stuff
       }
 
       // other stuff
     });
     ```
+
+## Arrow Functions
+  - When using ES2015 syntax and declaring your components as `class MyComponent extends React.Components {}` you should use arrow functions to define functions that will need to be bound to the components scope. This removes the need to have `.bind()` ran on every render. The arrow function will have the lexical `this` of the component.
+  ```javascript
+  // bad
+  onClick() {
+    // do stuff
+  }
+
+  render() {
+    return <a onClick={this.onClick.bind(this)}>Clicky Link</a>;
+  }
+
+  // good
+  onClick = () => {
+    // do stuff
+  }
+
+  render() {
+    return <a onClick={this.onClick}>Clickier Link</a>;
+  }
+  ```
+
+  For more information, please checkout the "Arrow Functions" section of [this article on ES2015+ React](http://babeljs.io/blog/2015/06/07/react-on-es6-plus/).
 
 ## Ordering
 

--- a/react/README.md
+++ b/react/README.md
@@ -247,7 +247,7 @@
     }
 
     render() {
-      return <a onClick={this.onClick.bind(this)}>Clicky</a>;
+      return <a onClick={this.onLinkClick.bind(this)}>Clicky</a>;
     }
   }
 
@@ -258,7 +258,7 @@
     }
 
     render() {
-      return <a onClick={this.onClick}>Clicky</a>;
+      return <a onClick={this.onLinkClick}>Clicky</a>;
     }
   }
   ```


### PR DESCRIPTION
This adds a section about using arrow functions in react components in order to use the components `this` scope inside the function. This only pertains to es2015 components.

[Inspired by this](http://babeljs.io/blog/2015/06/07/react-on-es6-plus/)
