### PR TITLE
Update no-extra-parens rule

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -149,7 +149,6 @@
         "newIsCap": true,
         "capIsNew": false
     }],
-    "no-extra-parens": 2,            // http://eslint.org/docs/rules/no-extra-parens.html
     "no-multiple-empty-lines": [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
       "max": 2
     }],

--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -149,6 +149,7 @@
         "newIsCap": true,
         "capIsNew": false
     }],
+    "no-extra-parens": [2, "functions"],            // http://eslint.org/docs/rules/no-extra-parens.html
     "no-multiple-empty-lines": [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
       "max": 2
     }],


### PR DESCRIPTION
## Description

Updated the `no-extra-parens` value to `[2, "functions"]` to allow jsx files to wrap multiline return values in parens (re: https://github.com/hudl/javascript/tree/master/react#parentheses) without the linter throwing an error. 
