### PR TITLE
Add switch rules to allow case indention at an additional 2 spaces

### DIFF
--- a/packages/eslint-config-hudl/rules/style.js
+++ b/packages/eslint-config-hudl/rules/style.js
@@ -32,7 +32,7 @@ module.exports = {
     'id-length': 0,
     // this option sets a specific tab width for your code
     // https://github.com/eslint/eslint/blob/master/docs/rules/indent.md
-    'indent': [2, 2, {"SwitchCase":1,"VariableDeclarator":1}],
+    'indent': [2, 2, {'SwitchCase':1,'VariableDeclarator':1}],
     // specify whether double or single quotes should be used in JSX attributes
     // http://eslint.org/docs/rules/jsx-quotes
     'jsx-quotes': [2],

--- a/packages/eslint-config-hudl/rules/style.js
+++ b/packages/eslint-config-hudl/rules/style.js
@@ -32,7 +32,7 @@ module.exports = {
     'id-length': 0,
     // this option sets a specific tab width for your code
     // https://github.com/eslint/eslint/blob/master/docs/rules/indent.md
-    'indent': [2, 2, {'SwitchCase':1,'VariableDeclarator':1}],
+    'indent': [2, 2, {'SwitchCase': 1,'VariableDeclarator': 1}],
     // specify whether double or single quotes should be used in JSX attributes
     // http://eslint.org/docs/rules/jsx-quotes
     'jsx-quotes': [2],

--- a/packages/eslint-config-hudl/rules/style.js
+++ b/packages/eslint-config-hudl/rules/style.js
@@ -32,7 +32,7 @@ module.exports = {
     'id-length': 0,
     // this option sets a specific tab width for your code
     // https://github.com/eslint/eslint/blob/master/docs/rules/indent.md
-    'indent': [2, 2],
+    'indent': [2, 2, {"SwitchCase": 1}],
     // specify whether double or single quotes should be used in JSX attributes
     // http://eslint.org/docs/rules/jsx-quotes
     'jsx-quotes': [2],

--- a/packages/eslint-config-hudl/rules/style.js
+++ b/packages/eslint-config-hudl/rules/style.js
@@ -32,7 +32,7 @@ module.exports = {
     'id-length': 0,
     // this option sets a specific tab width for your code
     // https://github.com/eslint/eslint/blob/master/docs/rules/indent.md
-    'indent': [2, 2, {'SwitchCase': 1,'VariableDeclarator': 1}],
+    'indent': [2, 2, {'SwitchCase': 1, 'VariableDeclarator': 1}],
     // specify whether double or single quotes should be used in JSX attributes
     // http://eslint.org/docs/rules/jsx-quotes
     'jsx-quotes': [2],

--- a/packages/eslint-config-hudl/rules/style.js
+++ b/packages/eslint-config-hudl/rules/style.js
@@ -32,7 +32,7 @@ module.exports = {
     'id-length': 0,
     // this option sets a specific tab width for your code
     // https://github.com/eslint/eslint/blob/master/docs/rules/indent.md
-    'indent': [2, 2, {"SwitchCase": 1}],
+    'indent': [2, 2, {"SwitchCase":1,"VariableDeclarator":1}],
     // specify whether double or single quotes should be used in JSX attributes
     // http://eslint.org/docs/rules/jsx-quotes
     'jsx-quotes': [2],


### PR DESCRIPTION
Following instructions from [this issue](https://github.com/airbnb/javascript/issues/296) to allow switch statements to be written like:

```
switch (myVar) {
  case 'case':
}
```

instead of:

```
switch (myVar) {
case 'case':
}
```
