### PR TITLE
Update eslint peer dependency to be more accurate

### DIFF
--- a/packages/eslint-config-hudl/package.json
+++ b/packages/eslint-config-hudl/package.json
@@ -91,6 +91,6 @@
     "tmp": "0.0.28"
   },
   "peerDependencies": {
-    "eslint": ">=1.0.0"
+    "eslint": "^1.0.0"
   }
 }


### PR DESCRIPTION
This config is not compatible with eslint 2.x (and should not have expected to have been). A peer dependency on `eslint >= 1.0.0` was not accurate and doesn't give any warning when installing with newer versions of ESLint.

This PR will cause install warnings and/or errors to catch the problem sooner.
