### PR TITLE
Update "extends" example to use hudl instead of airbnb

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -2,5 +2,5 @@
 // Copy this file, and add rule overrides as needed.
 {
   "root": true,
-  "extends": "airbnb"
+  "extends": "hudl"
 }


### PR DESCRIPTION
The example `.eslintrc` still said `"extends": "airbnb"`, instead of using `hudl`. Correcting this.
