### PR TITLE
Update Trailing or Leading Underscore Convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1711,15 +1711,18 @@ Forked from [AirBNB's style guide](https://github.com/airbnb/javascript)
     }
     ```
 
-  - [22.5](#22.5) <a name='22.5'></a> Use a leading underscore `_` when naming private properties.
+  - [22.5](#22.5) <a name='22.5'></a> Do not use trailing or leading underscores.
+
+    > Why? JavaScript does not have the concept of privacy in terms of properties or methods. Although a leading underscore is a common convention to mean “private”, in fact, these properties are fully public, and as such, are part of your public API contract. This convention might lead developers to wrongly think that a change won't count as breaking, or that tests aren't needed. tl;dr: if you want something to be “private”, it must not be observably present.
 
     ```javascript
     // bad
     this.__firstName__ = 'Panda';
     this.firstName_ = 'Panda';
+    this._firstName = 'Panda';
 
     // good
-    this._firstName = 'Panda';
+    this.firstName = 'Panda';
     ```
 
   - [22.6](#22.6) <a name='22.6'></a> Don't save references to `this`. Use arrow functions or Function#bind.

--- a/README.md
+++ b/README.md
@@ -1715,15 +1715,39 @@ Forked from [AirBNB's style guide](https://github.com/airbnb/javascript)
 
     > Why? JavaScript does not have the concept of privacy in terms of properties or methods. Although a leading underscore is a common convention to mean “private”, in fact, these properties are fully public, and as such, are part of your public API contract. This convention might lead developers to wrongly think that a change won't count as breaking, or that tests aren't needed. tl;dr: if you want something to be “private”, it must not be observably present.
 
-    ```javascript
-    // bad
-    this.__firstName__ = 'Panda';
-    this.firstName_ = 'Panda';
-    this._firstName = 'Panda';
+    - Do not use underscores when naming properties
 
-    // good
-    this.firstName = 'Panda';
-    ```
+      ```javascript
+      // bad
+      this.__firstName__ = 'Panda';
+      this.firstName_ = 'Panda';
+      this._firstName = 'Panda';
+
+      // good
+      this.firstName = 'Panda';
+      ```
+
+    - Do not use an underscore prefix for internal methods
+
+      ```jsx
+      // bad
+      React.createClass({
+        _onClickSubmit() {
+          // do stuff
+        },
+
+        // other stuff
+      });
+
+      // good
+      class extends React.Component {
+        onClickSubmit() {
+          // do stuff
+        }
+
+        // other stuff
+      }
+      ```
 
   - [22.6](#22.6) <a name='22.6'></a> Don't save references to `this`. Use arrow functions or Function#bind.
 


### PR DESCRIPTION
As per our [discussion in #front-end-guild](https://hudl.slack.com/archives/front-end-guild/p1479479352000063) I've updated the underscore naming convention to align with the airbnb guide.

There's also a [note here at the third bullet point](https://github.com/airbnb/javascript/tree/master/react#methods) about not using underscore prefixes specifically in react components.