### PR TITLE
update switch case and react multi components

### DIFF
--- a/packages/eslint-config-hudl/CHANGELOG.md
+++ b/packages/eslint-config-hudl/CHANGELOG.md
@@ -1,8 +1,7 @@
 
-6.0.0
-- [breaking]
-    + Update Switch Case indent
-	+ Update Multi react components to ignore stateless
+### 6.0.0 / 2018-01-18
+- [breaking] Updated indentation for switch statements
+- [minor] allow multiple stateless react components in a single file
 
 ### 5.0.1
 - Update references to http://npm.thorhudl.com to reference new Nexus server.

--- a/packages/eslint-config-hudl/CHANGELOG.md
+++ b/packages/eslint-config-hudl/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+6.0.0
+- [breaking]
+    + Update Switch Case indent
+	+ Update Multi react components to ignore stateless
+
 ### 5.0.1
 - Update references to http://npm.thorhudl.com to reference new Nexus server.
 

--- a/packages/eslint-config-hudl/docs/comparisons/with-airbnb-master.md
+++ b/packages/eslint-config-hudl/docs/comparisons/with-airbnb-master.md
@@ -546,7 +546,7 @@ should be added to the list in [the diff task](../../tasks/docs/diffs/diffs-to-r
   - [<ins>&quot;error&quot;</ins>, <ins>{&quot;before&quot;:false,&quot;after&quot;:true}</ins>]
 - 
     [indent](http://eslint.org/docs/rules/indent.html)
-  - [&quot;error&quot;, 2]
+  - [&quot;error&quot;, 2, <del>{&quot;SwitchCase&quot;:1,&quot;VariableDeclarator&quot;:1}</del>]
   - [&quot;error&quot;, 2, <ins>{&quot;SwitchCase&quot;:1,&quot;VariableDeclarator&quot;:1,&quot;outerIIFEBody&quot;:1,&quot;FunctionDeclaration&quot;:{&quot;parameters&quot;:1,&quot;body&quot;:1},&quot;FunctionExpression&quot;:{&quot;parameters&quot;:1,&quot;body&quot;:1}}</ins>]
 - 
     [jsx-quotes](http://eslint.org/docs/rules/jsx-quotes.html)
@@ -809,9 +809,6 @@ should be added to the list in [the diff task](../../tasks/docs/diffs/diffs-to-r
 -     react/no-is-mounted
   - [<del>&quot;off&quot;</del>]
   - [<ins>&quot;error&quot;</ins>]
--     react/no-multi-comp
-  - [&quot;error&quot;]
-  - [&quot;error&quot;, <ins>{&quot;ignoreStateless&quot;:true}</ins>]
 -     react/no-string-refs
   - [<del>&quot;off&quot;</del>]
   - [<ins>&quot;error&quot;</ins>]

--- a/packages/eslint-config-hudl/docs/comparisons/with-airbnb-master.md
+++ b/packages/eslint-config-hudl/docs/comparisons/with-airbnb-master.md
@@ -447,8 +447,6 @@ should be added to the list in [the diff task](../../tasks/docs/diffs/diffs-to-r
   - [<ins>&quot;off&quot;</ins>, <ins>{&quot;ignoreCase&quot;:true,&quot;callbacksLast&quot;:false,&quot;requiredFirst&quot;:false}</ins>]
 -     react/style-prop-object
   - [<ins>&quot;error&quot;</ins>]
--     react/wrap-multilines
-  - [<ins>&quot;off&quot;</ins>]
 - 
     [require-await](http://eslint.org/docs/rules/require-await.html)
   - [<ins>&quot;off&quot;</ins>]
@@ -824,6 +822,9 @@ should be added to the list in [the diff task](../../tasks/docs/diffs/diffs-to-r
 -     react/sort-comp
   - [&quot;error&quot;]
   - [&quot;error&quot;, <ins>{&quot;order&quot;:[&quot;static-methods&quot;,&quot;lifecycle&quot;,&quot;/^on.+$/&quot;,&quot;/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/&quot;,&quot;everything-else&quot;,&quot;/^render.+$/&quot;,&quot;render&quot;]}</ins>]
+-     react/wrap-multilines
+  - [<del>&quot;error&quot;</del>]
+  - [<ins>&quot;off&quot;</ins>]
 - 
     [require-yield](http://eslint.org/docs/rules/require-yield.html)
   - [<del>&quot;off&quot;</del>]

--- a/packages/eslint-config-hudl/package.json
+++ b/packages/eslint-config-hudl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hudl",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Hudl's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-hudl/rules/react.js
+++ b/packages/eslint-config-hudl/rules/react.js
@@ -108,7 +108,7 @@ module.exports = {
     'react/no-is-mounted': 'off',
     // Prevent multiple component definition per file
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
-    'react/no-multi-comp': ['error'],
+    'react/no-multi-comp': ['error', {"ignoreStateless": true}],
     // Prevent usage of setState
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-set-state.md
     'react/no-set-state': 'off',

--- a/packages/eslint-config-hudl/rules/react.js
+++ b/packages/eslint-config-hudl/rules/react.js
@@ -108,7 +108,7 @@ module.exports = {
     'react/no-is-mounted': 'off',
     // Prevent multiple component definition per file
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
-    'react/no-multi-comp': ['error', {"ignoreStateless": true}],
+    'react/no-multi-comp': ['error', { 'ignoreStateless': true }],
     // Prevent usage of setState
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-set-state.md
     'react/no-set-state': 'off',

--- a/packages/eslint-config-hudl/rules/react.js
+++ b/packages/eslint-config-hudl/rules/react.js
@@ -141,5 +141,6 @@ module.exports = {
     // Prevent missing parentheses around multilines JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
     'react/jsx-wrap-multilines': ['error'],
+    'react/wrap-multilines': ['error'],
   },
 };

--- a/packages/eslint-config-hudl/rules/style.js
+++ b/packages/eslint-config-hudl/rules/style.js
@@ -32,7 +32,7 @@ module.exports = {
     'id-length': 'off',
     // this option sets a specific tab width for your code
     // https://github.com/eslint/eslint/blob/master/docs/rules/indent.md
-    'indent': ['error', 2, {"SwitchCase":1,"VariableDeclarator":1}],
+    'indent': ['error', 2, { 'SwitchCase': 1, 'VariableDeclarator': 1 }],
     // specify whether double or single quotes should be used in JSX attributes
     // http://eslint.org/docs/rules/jsx-quotes
     'jsx-quotes': ['error'],

--- a/packages/eslint-config-hudl/rules/style.js
+++ b/packages/eslint-config-hudl/rules/style.js
@@ -32,7 +32,7 @@ module.exports = {
     'id-length': 'off',
     // this option sets a specific tab width for your code
     // https://github.com/eslint/eslint/blob/master/docs/rules/indent.md
-    'indent': ['error', 2],
+    'indent': ['error', 2, {"SwitchCase":1,"VariableDeclarator":1}],
     // specify whether double or single quotes should be used in JSX attributes
     // http://eslint.org/docs/rules/jsx-quotes
     'jsx-quotes': ['error'],


### PR DESCRIPTION
Fix indentation on switch statements
Allow multiple react components per file (as long as they are stateless)

Made this a major update since the change in spacing would cause build errors