### PR TITLE
remove react/wrap-multilines

### DIFF
--- a/packages/eslint-config-hudl/CHANGELOG.md
+++ b/packages/eslint-config-hudl/CHANGELOG.md
@@ -1,116 +1,115 @@
+### 6.0.1 / 2018-02-23
+
+* [bug] Remove react/wrap-multilines
 
 ### 6.0.0 / 2018-01-18
-- [breaking] Updated indentation for switch statements
-- [minor] allow multiple stateless react components in a single file
+
+* [breaking] Updated indentation for switch statements
+* [minor] allow multiple stateless react components in a single file
 
 ### 5.0.1
-- Update references to http://npm.thorhudl.com to reference new Nexus server.
 
-5.0.0 / 2017-02-14 (Hudl)
-==================
-- [breaking] Updated eslint-config-hudl dependencies
-    + Required some structural changes to .eslintrc options
-    + Removed comparison with rules before packaging refactor (super old and caused errors on tests)
-    + Updated docs comparison to eslint-config-airbnb@14.1.0 (lots of differences - job for another PR?)
-    + Updated a few rules that have changed
-    + Fixed ConfigDiff code to handle the new configs
-    + Applied new eslint rules to the code itself as required
+* Update references to http://npm.thorhudl.com to reference new Nexus server.
 
-4.0.1 / 2016-03-09 (Hudl)
-==================
- - Update eslint peer dependency to only be compatible with 1.x
+  # 5.0.0 / 2017-02-14 (Hudl)
 
-4.0.0 / 2016-01-22
-==================
- - [breaking] require outer IIFE wrapping; flesh out guide section
- - [minor] Add missing `arrow-body-style`, `prefer-template` rules (#678)
- - [minor] Add `prefer-arrow-callback` to ES6 rules (to match the guide) (#677)
- - [Tests] run `npm run lint` as part of tests; fix errors
- - [Tests] use `parallelshell` to parallelize npm run-scripts
+* [breaking] Updated eslint-config-hudl dependencies + Required some structural changes to .eslintrc options + Removed comparison with rules before packaging refactor (super old and caused errors on tests) + Updated docs comparison to eslint-config-airbnb@14.1.0 (lots of differences - job for another PR?) + Updated a few rules that have changed + Fixed ConfigDiff code to handle the new configs + Applied new eslint rules to the code itself as required
 
-3.1.0 / 2016-01-07
-==================
- - [minor] Allow multiple stateless components in a single file
+  # 4.0.1 / 2016-03-09 (Hudl)
 
-3.0.2 / 2016-01-06
-==================
- - [fix] Ignore URLs in `max-len` (#664)
+* Update eslint peer dependency to only be compatible with 1.x
 
-3.0.1 / 2016-01-06
-==================
- - [fix] because we use babel, keywords should not be quoted
+# 4.0.0 / 2016-01-22
 
-3.0.0 / 2016-01-04
-==================
- - [breaking] enable `quote-props` rule (#632)
- - [breaking] Define a max line length of 100 characters (#639)
- - [breaking] [react] Minor cleanup for the React styleguide, add `react/jsx-no-bind` (#619)
- - [breaking] update best-practices config to prevent parameter object manipulation (#627)
- - [minor] Enable react/no-is-mounted rule (#635, #633)
- - [minor] Sort react/prefer-es6-class alphabetically (#634)
- - [minor] enable react/prefer-es6-class rule
- - Permit strict mode in "legacy" config
- - [react] add missing rules from eslint-plugin-react (enforcing where necessary) (#581)
- - [dev deps] update `eslint-plugin-react`
+* [breaking] require outer IIFE wrapping; flesh out guide section
+* [minor] Add missing `arrow-body-style`, `prefer-template` rules (#678)
+* [minor] Add `prefer-arrow-callback` to ES6 rules (to match the guide) (#677)
+* [Tests] run `npm run lint` as part of tests; fix errors
+* [Tests] use `parallelshell` to parallelize npm run-scripts
 
-2.1.1 / 2015-12-15
-==================
- - [fix] Remove deprecated react/jsx-quotes (#622)
+# 3.1.0 / 2016-01-07
 
-2.1.0 / 2015-12-15
-==================
- - [fix] use `require.resolve` to allow nested `extend`s (#582)
- - [new] enable `object-shorthand` rule (#621)
- - [new] enable `arrow-spacing` rule (#517)
- - [docs] flesh out react rule defaults (#618)
+* [minor] Allow multiple stateless components in a single file
 
-2.0.0 / 2015-12-03
-==================
- - [breaking] `space-before-function-paren`: require function spacing: `function <optional name>(` (#605)
- - [breaking] `indent`: Fix switch statement indentation rule (#606)
- - [breaking] `array-bracket-spacing`, `computed-property-spacing`: disallow spacing inside brackets (#594)
- - [breaking] `object-curly-spacing`: require padding inside curly braces (#594)
- - [breaking] `space-in-parens`: disallow spaces in parens (#594)
+# 3.0.2 / 2016-01-06
 
-1.0.2 / 2015-11-25
-==================
- - [breaking] `no-multiple-empty-lines`: only allow 1 blank line at EOF (#578)
- - [new] `restParams`: enable rest params (#592)
+* [fix] Ignore URLs in `max-len` (#664)
 
-1.0.1 / 2015-11-25
-==================
- - *erroneous publish*
+# 3.0.1 / 2016-01-06
 
-1.0.0 / 2015-11-08
-==================
- - require `eslint` `v1.0.0` or higher
- - remove `babel-eslint` dependency
+* [fix] because we use babel, keywords should not be quoted
 
-0.1.1 / 2015-11-05
-==================
- - remove id-length rule (#569)
- - enable `no-mixed-spaces-and-tabs` (#539)
- - enable `no-const-assign` (#560)
- - enable `space-before-keywords` (#554)
+# 3.0.0 / 2016-01-04
 
-0.1.0 / 2015-11-05
-==================
- - switch to modular rules files courtesy the [eslint-config-default][ecd] project and [@taion][taion]. [PR][pr-modular]
- - export `eslint-config-airbnb/legacy` for ES5-only users. `eslint-config-airbnb/legacy` does not require the `babel-eslint` parser. [PR][pr-legacy]
+* [breaking] enable `quote-props` rule (#632)
+* [breaking] Define a max line length of 100 characters (#639)
+* [breaking][react] Minor cleanup for the React styleguide, add `react/jsx-no-bind` (#619)
+* [breaking] update best-practices config to prevent parameter object manipulation (#627)
+* [minor] Enable react/no-is-mounted rule (#635, #633)
+* [minor] Sort react/prefer-es6-class alphabetically (#634)
+* [minor] enable react/prefer-es6-class rule
+* Permit strict mode in "legacy" config
+* [react] add missing rules from eslint-plugin-react (enforcing where necessary) (#581)
+* [dev deps] update `eslint-plugin-react`
 
-0.0.9 / 2015-09-24
-==================
-- add rule `no-undef`
-- add rule `id-length`
+# 2.1.1 / 2015-12-15
 
-0.0.8 / 2015-08-21
-==================
- - now has a changelog
- - now is modular (see instructions above for with react and without react versions)
+* [fix] Remove deprecated react/jsx-quotes (#622)
 
-0.0.7 / 2015-07-30
-==================
- - TODO: fill in
+# 2.1.0 / 2015-12-15
+
+* [fix] use `require.resolve` to allow nested `extend`s (#582)
+* [new] enable `object-shorthand` rule (#621)
+* [new] enable `arrow-spacing` rule (#517)
+* [docs] flesh out react rule defaults (#618)
+
+# 2.0.0 / 2015-12-03
+
+* [breaking] `space-before-function-paren`: require function spacing: `function <optional name>(` (#605)
+* [breaking] `indent`: Fix switch statement indentation rule (#606)
+* [breaking] `array-bracket-spacing`, `computed-property-spacing`: disallow spacing inside brackets (#594)
+* [breaking] `object-curly-spacing`: require padding inside curly braces (#594)
+* [breaking] `space-in-parens`: disallow spaces in parens (#594)
+
+# 1.0.2 / 2015-11-25
+
+* [breaking] `no-multiple-empty-lines`: only allow 1 blank line at EOF (#578)
+* [new] `restParams`: enable rest params (#592)
+
+# 1.0.1 / 2015-11-25
+
+* _erroneous publish_
+
+# 1.0.0 / 2015-11-08
+
+* require `eslint` `v1.0.0` or higher
+* remove `babel-eslint` dependency
+
+# 0.1.1 / 2015-11-05
+
+* remove id-length rule (#569)
+* enable `no-mixed-spaces-and-tabs` (#539)
+* enable `no-const-assign` (#560)
+* enable `space-before-keywords` (#554)
+
+# 0.1.0 / 2015-11-05
+
+* switch to modular rules files courtesy the [eslint-config-default][ecd] project and [@taion][taion]. [PR][pr-modular]
+* export `eslint-config-airbnb/legacy` for ES5-only users. `eslint-config-airbnb/legacy` does not require the `babel-eslint` parser. [PR][pr-legacy]
+
+# 0.0.9 / 2015-09-24
+
+* add rule `no-undef`
+* add rule `id-length`
+
+  # 0.0.8 / 2015-08-21
+
+* now has a changelog
+* now is modular (see instructions above for with react and without react versions)
+
+# 0.0.7 / 2015-07-30
+
+* TODO: fill in
 
 [ecd]: https://github.com/walmartlabs/eslint-config-defaults
 [taion]: https://github.com/taion

--- a/packages/eslint-config-hudl/docs/comparisons/with-airbnb-master.md
+++ b/packages/eslint-config-hudl/docs/comparisons/with-airbnb-master.md
@@ -447,6 +447,8 @@ should be added to the list in [the diff task](../../tasks/docs/diffs/diffs-to-r
   - [<ins>&quot;off&quot;</ins>, <ins>{&quot;ignoreCase&quot;:true,&quot;callbacksLast&quot;:false,&quot;requiredFirst&quot;:false}</ins>]
 -     react/style-prop-object
   - [<ins>&quot;error&quot;</ins>]
+-     react/wrap-multilines
+  - [<ins>&quot;off&quot;</ins>]
 - 
     [require-await](http://eslint.org/docs/rules/require-await.html)
   - [<ins>&quot;off&quot;</ins>]
@@ -822,9 +824,6 @@ should be added to the list in [the diff task](../../tasks/docs/diffs/diffs-to-r
 -     react/sort-comp
   - [&quot;error&quot;]
   - [&quot;error&quot;, <ins>{&quot;order&quot;:[&quot;static-methods&quot;,&quot;lifecycle&quot;,&quot;/^on.+$/&quot;,&quot;/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/&quot;,&quot;everything-else&quot;,&quot;/^render.+$/&quot;,&quot;render&quot;]}</ins>]
--     react/wrap-multilines
-  - [<del>&quot;error&quot;</del>]
-  - [<ins>&quot;off&quot;</ins>]
 - 
     [require-yield](http://eslint.org/docs/rules/require-yield.html)
   - [<del>&quot;off&quot;</del>]

--- a/packages/eslint-config-hudl/package.json
+++ b/packages/eslint-config-hudl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hudl",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Hudl's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {
@@ -47,10 +47,7 @@
   },
   "tasksConfig": {
     "test": {
-      "src": [
-        "lib/**/*.js",
-        "!**/__specs__/**/*.js"
-      ],
+      "src": ["lib/**/*.js", "!**/__specs__/**/*.js"],
       "tests": "**/*-specs.js",
       "setup": "./test/setup",
       "coverageThresholds": {

--- a/packages/eslint-config-hudl/rules/react.js
+++ b/packages/eslint-config-hudl/rules/react.js
@@ -1,28 +1,32 @@
 module.exports = {
-  'parser': 'babel-eslint',
-  'plugins': [
-    'react',
-  ],
-  'parserOptions': {
-    'ecmaVersion': 6,
-    'sourceType': 'module',
-    'ecmaFeatures': {
-      'jsx': true,
+  parser: 'babel-eslint',
+  plugins: ['react'],
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
     },
   },
   // View link below for react rules documentation
   // https://github.com/yannickcr/eslint-plugin-react#list-of-supported-rules
-  'rules': {
+  rules: {
     // Prevent missing displayName in a React component definition
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
-    'react/display-name': ['off', {
-      'acceptTranspilerName': false,
-    }],
+    'react/display-name': [
+      'off',
+      {
+        acceptTranspilerName: false,
+      },
+    ],
     // Forbid certain propTypes (any, array, object)
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md
-    'react/forbid-prop-types': ['off', {
-      'forbid': ['any', 'array', 'object'],
-    }],
+    'react/forbid-prop-types': [
+      'off',
+      {
+        forbid: ['any', 'array', 'object'],
+      },
+    ],
     // Enforce boolean attributes notation in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
     'react/jsx-boolean-value': ['error'],
@@ -31,15 +35,22 @@ module.exports = {
     'react/jsx-closing-bracket-location': ['off', 'line-aligned'],
     // Enforce or disallow spaces inside of curly braces in JSX attributes
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
-    'react/jsx-curly-spacing': ['off', 'never', {
-      'allowMultiline': true,
-    }],
+    'react/jsx-curly-spacing': [
+      'off',
+      'never',
+      {
+        allowMultiline: true,
+      },
+    ],
     // Enforce event handler naming conventions in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
-    'react/jsx-handler-names': ['off', {
-      'eventHandlerPrefix': 'handle',
-      'eventHandlerPropPrefix': 'on',
-    }],
+    'react/jsx-handler-names': [
+      'off',
+      {
+        eventHandlerPrefix: 'handle',
+        eventHandlerPropPrefix: 'on',
+      },
+    ],
     // Validate props indentation in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
     'react/jsx-indent-props': ['off', 2],
@@ -48,17 +59,23 @@ module.exports = {
     'react/jsx-key': 'off',
     // Limit maximum of props on a single line in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
-    'react/jsx-max-props-per-line': ['off', {
-      'maximum': 1,
-    }],
+    'react/jsx-max-props-per-line': [
+      'off',
+      {
+        maximum: 1,
+      },
+    ],
     // Prevent usage of .bind() and arrow functions in JSX props
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
     'react/jsx-no-bind': 'off',
     // Prevent duplicate props in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md
-    'react/jsx-no-duplicate-props': ['off', {
-      'ignoreCase': false,
-    }],
+    'react/jsx-no-duplicate-props': [
+      'off',
+      {
+        ignoreCase: false,
+      },
+    ],
     // Prevent usage of unwrapped JSX strings
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md
     'react/jsx-no-literals': 'off',
@@ -70,16 +87,22 @@ module.exports = {
     'react/jsx-pascal-case': 'off',
     // Enforce propTypes declarations alphabetical sorting
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
-    'react/jsx-sort-prop-types': ['off', {
-      'ignoreCase': false,
-      'callbacksLast': false,
-    }],
+    'react/jsx-sort-prop-types': [
+      'off',
+      {
+        ignoreCase: false,
+        callbacksLast: false,
+      },
+    ],
     // Enforce props alphabetical sorting
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
-    'react/jsx-sort-props': ['off', {
-      'ignoreCase': false,
-      'callbacksLast': false,
-    }],
+    'react/jsx-sort-props': [
+      'off',
+      {
+        ignoreCase: false,
+        callbacksLast: false,
+      },
+    ],
     // Prevent React to be incorrectly marked as unused
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
     'react/jsx-uses-react': ['error'],
@@ -91,9 +114,12 @@ module.exports = {
     'react/no-danger': 'off',
     // Prevent usage of deprecated methods
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md
-    'react/no-deprecated': ['off', {
-      'react': '0.14.0',
-    }],
+    'react/no-deprecated': [
+      'off',
+      {
+        react: '0.14.0',
+      },
+    ],
     // Prevent usage of setState in componentDidMount
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
     'react/no-did-mount-set-state': 'error',
@@ -108,7 +134,7 @@ module.exports = {
     'react/no-is-mounted': 'off',
     // Prevent multiple component definition per file
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
-    'react/no-multi-comp': ['error', { 'ignoreStateless': true }],
+    'react/no-multi-comp': ['error', { ignoreStateless: true }],
     // Prevent usage of setState
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-set-state.md
     'react/no-set-state': 'off',
@@ -129,9 +155,12 @@ module.exports = {
     'react/react-in-jsx-scope': 'error',
     // Restrict file extensions that may be required
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-extension.md
-    'react/require-extension': ['off', {
-      'extensions': ['.jsx'],
-    }],
+    'react/require-extension': [
+      'off',
+      {
+        extensions: ['.jsx'],
+      },
+    ],
     // Prevent extra closing tags for components without children
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
     'react/self-closing-comp': 'error',
@@ -141,6 +170,5 @@ module.exports = {
     // Prevent missing parentheses around multilines JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
     'react/jsx-wrap-multilines': ['error'],
-    'react/wrap-multilines': ['error'],
   },
 };


### PR DESCRIPTION
I inadvertently added a react/wrap-multilines when I was testing a fix. This removes that from 6.0.0.

Then prettier decided to fix a bunch of things :)