### PR TITLE
FEP-6212 - Adds notice about deprecation, removes CI build code

### DIFF
--- a/ci/teamcity-build.sh
+++ b/ci/teamcity-build.sh
@@ -1,7 +1,2 @@
 #!/usr/bin/env bash
-set -ex
-
-cd "$( dirname "${BASH_SOURCE[0]}" )"
-
-docker-compose -f docker-compose.yml build  $service-build
-docker-compose -f docker-compose.yml run --rm  $service-build
+echo "This package is deprecated in this repo - please use https://github.com/hudl/hudl-frontends/tree/main/config/config-eslint"

--- a/packages/eslint-config-hudl/README.md
+++ b/packages/eslint-config-hudl/README.md
@@ -1,3 +1,7 @@
+# 🚨 NOTICE 🚨
+
+**🚨 This package has been deprecated in favor of https://github.com/hudl/hudl-frontends/tree/main/config/config-eslint.  Do not make any more changes to this package! 🚨**
+
 # eslint-config-hudl
 
 This package provides Hudl's .eslintrc as an extensible shared config.


### PR DESCRIPTION
This PR adds a README notice about the `eslint-config-hudl` package being deprecated here.